### PR TITLE
Add headless GUI flow and CRAFT reference

### DIFF
--- a/Documentacion/DLE_400_01_Manual_CRAFT.md
+++ b/Documentacion/DLE_400_01_Manual_CRAFT.md
@@ -1,0 +1,40 @@
+---
+title: "Manual Rápido de CRAFT"
+version: "0.1.0"
+date: "2024-02-15"
+status: "draft"
+author: "Dungeon Life Core Team"
+tags: ["framework", "CRAFT", "metodologia", "diseño", "produccion"]
+---
+
+# 🛠️ ¿Qué es CRAFT?
+
+CRAFT es el **Creative Framework for Augmented Fantasy Teams**, la metodología de diseño
+colaborativo que emplea Dungeon Life para pasar de una idea narrativa a entregables
+jugables y verificables. El acrónimo resume sus cinco etapas recurrentes:
+
+| Letra | Etapa | Enfoque principal |
+| --- | --- | --- |
+| **C** | **Conceptualize** | Alinear visión, restricciones y público objetivo. |
+| **R** | **Research** | Mapear referencias, lore canónico y datos técnicos. |
+| **A** | **Assemble** | Prototipar mecánicas, UI y activos narrativos mínimos. |
+| **F** | **Forge** | Integrar assets finales respetando atlas de pilares y QA. |
+| **T** | **Test** | Validar experiencia con métricas jugables y feedback cruzado. |
+
+## 🎯 Propósito
+
+- Mantener sincronizadas a las células de lore, gameplay, arte y datos.
+- Traducir decisiones creativas en artefactos rastreables dentro del Atlas DLE.
+- Servir como puente entre frameworks hermanos como FES, DMTE e IRON.
+
+## 🔁 Flujo resumido
+
+1. **Briefing C**: definición de objetivos y entregables esperados.
+2. **Research board**: documentación relevante, referencias visuales y análisis de riesgos.
+3. **Playground A**: creación rápida en entornos como Unreal o Godot con activos placeholder.
+4. **Forge build**: assets definitivos validados con checklists de calidad.
+5. **Trials T**: sesiones de juego, telemetría y retroalimentación del equipo narrativo.
+
+El ciclo puede iterarse parcial o totalmente según el tipo de misión o asset. Cada fase
+emite reportes compatibles con el sistema de memoria colectiva del agente, lo que permite
+que Willow trace el contexto al responder consultas en tiempo real.

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Toda la información detallada se encuentra en la carpeta [`Documentacion/`](./D
 | **[🏷️ 05_Taxonomia_y_Nomenclatura.md](./Documentacion/05_Taxonomia_y_Nomenclatura.md)** | Sistema de clasificación | Arquitectos |
 | **[🚀 06_Instalacion_y_Configuracion.md](./Documentacion/06_Instalacion_y_Configuracion.md)** | Guía de instalación | Desarrolladores |
 | **[👥 07_Guia_Usuario.md](./Documentacion/07_Guia_Usuario.md)** | Guía completa de uso | Todos |
+| **[🛠️ DLE_400_01_Manual_CRAFT.md](./Documentacion/DLE_400_01_Manual_CRAFT.md)** | Metodología CRAFT detallada | Equipos creativos |
 
 ### 🎯 **Especialización por Roles**
 
@@ -107,6 +108,12 @@ python scripts/setup_agent.py
 
 # 4. Primer encuentro con Willow
 python run_agent.py
+
+# También puedes abrir la nueva interfaz visual minimalista
+python run_gui.py
+
+# O ejecutar una consulta rápida en modo headless (útil en CI)
+python run_gui.py --ask "¿Sabes qué es CRAFT?" --no-gui
 
 # También puedes usar la nueva interfaz de línea de comandos
 willow --mode consultor "¿Qué describe la arquitectura técnica?"

--- a/dungeon_life_agent/gui.py
+++ b/dungeon_life_agent/gui.py
@@ -1,0 +1,198 @@
+"""Interfaz gráfica minimalista para conversar con Willow mediante CustomTkinter."""
+
+from __future__ import annotations
+
+import os
+import sys
+
+try:  # pragma: no cover - import opcional para entornos headless
+    import customtkinter as ctk
+except ModuleNotFoundError:  # pragma: no cover - degradado controlado
+    ctk = None  # type: ignore[assignment]
+
+from .agent import DungeonLifeAgent
+from .interactive import HELP_TEXT, process_interactive_message
+
+
+DEFAULT_GREETING = "Me alegro de verte, guardián. ¿Listo para explorar el bosque digital?"
+
+
+if ctk is not None:
+
+    class AgentChatApp(ctk.CTk):
+        """Ventana principal del chat con Willow."""
+
+        def __init__(
+            self,
+            agent: DungeonLifeAgent | None = None,
+            *,
+            greeting: str | None = None,
+        ) -> None:
+            super().__init__()
+
+            ctk.set_appearance_mode("dark")
+            ctk.set_default_color_theme("dark-blue")
+
+            self.title("Willow · Dungeon Life Agent")
+            self.geometry("900x600")
+            self.minsize(720, 480)
+
+            self.agent = agent or DungeonLifeAgent()
+            self.greeting = greeting or DEFAULT_GREETING
+
+            self.columnconfigure(0, weight=1)
+            self.rowconfigure(1, weight=1)
+
+            self._build_header()
+            self._build_chat_area()
+            self._build_input_area()
+
+            self._append_message("Willow", self.greeting)
+
+            self.entry.focus_set()
+
+            self.bind("<Return>", self._on_return)
+            self.protocol("WM_DELETE_WINDOW", self._on_close)
+
+        def _build_header(self) -> None:
+            header = ctk.CTkFrame(self, fg_color="transparent")
+            header.grid(row=0, column=0, pady=(24, 12), sticky="ew")
+            header.columnconfigure(0, weight=1)
+
+            title = ctk.CTkLabel(
+                header,
+                text="Willow",
+                font=("Segoe UI", 28, "bold"),
+                anchor="w",
+            )
+            title.grid(row=0, column=0, sticky="w", padx=24)
+
+            subtitle = ctk.CTkLabel(
+                header,
+                text="Tu guardián digital de Dungeon Life",
+                font=("Segoe UI", 14),
+                text_color=("#a0a0a0", "#d0d0d0"),
+                anchor="w",
+            )
+            subtitle.grid(row=1, column=0, sticky="w", padx=24, pady=(4, 0))
+
+        def _build_chat_area(self) -> None:
+            self.chat_display = ctk.CTkTextbox(
+                self,
+                wrap="word",
+                font=("Segoe UI", 14),
+            )
+            self.chat_display.grid(row=1, column=0, padx=24, sticky="nsew")
+            self.chat_display.configure(state="disabled")
+
+        def _build_input_area(self) -> None:
+            container = ctk.CTkFrame(self, corner_radius=18, fg_color="#111")
+            container.grid(row=2, column=0, padx=24, pady=24, sticky="ew")
+            container.columnconfigure(0, weight=1)
+
+            self.entry = ctk.CTkEntry(
+                container,
+                placeholder_text="Pregunta lo que quieras",
+                font=("Segoe UI", 14),
+            )
+            self.entry.grid(row=0, column=0, padx=(16, 8), pady=16, sticky="ew")
+
+            send_button = ctk.CTkButton(
+                container,
+                text="Enviar",
+                command=self._on_send,
+                width=120,
+            )
+            send_button.grid(row=0, column=1, padx=(8, 16), pady=16)
+
+            help_button = ctk.CTkButton(
+                container,
+                text="?",
+                width=48,
+                command=self._show_help,
+            )
+            help_button.grid(row=0, column=2, padx=(0, 16), pady=16)
+
+        def _append_message(self, author: str, text: str) -> None:
+            if not text:
+                return
+            self.chat_display.configure(state="normal")
+            self.chat_display.insert("end", f"{author}: {text.strip()}\n\n")
+            self.chat_display.configure(state="disabled")
+            self.chat_display.see("end")
+
+        def _on_return(self, event) -> None:  # type: ignore[override]
+            if event.state & 0x0001:  # Shift presionado para salto de línea
+                return
+            self._on_send()
+
+        def _on_send(self) -> None:
+            message = self.entry.get().strip()
+            if not message:
+                return
+
+            self.entry.delete(0, "end")
+            self._append_message("Tú", message)
+
+            should_continue, response = process_interactive_message(
+                self.agent, message, show_debug=False
+            )
+            if response:
+                self._append_message("Willow", response)
+
+            if not should_continue:
+                self.after(200, self.destroy)
+
+        def _show_help(self) -> None:
+            self._append_message("Willow", HELP_TEXT)
+
+        def _on_close(self) -> None:
+            self.destroy()
+
+else:
+
+    class AgentChatApp:  # pragma: no cover - stub minimal para entornos sin CustomTkinter
+        """Stub que informa la ausencia de CustomTkinter."""
+
+        def __init__(self, *_, **__) -> None:
+            raise RuntimeError(
+                "CustomTkinter no está instalado. Instala la dependencia para abrir la ventana."
+            )
+
+
+def launch_app() -> None:
+    """Crea el agente y lanza la aplicación gráfica."""
+
+    if ctk is None:
+        raise RuntimeError(
+            "CustomTkinter no está disponible en este entorno. Ejecuta 'pip install customtkinter'."
+        )
+    app = AgentChatApp()
+    app.mainloop()
+
+
+def supports_windowing() -> bool:
+    """Indica si parece existir un entorno gráfico disponible."""
+
+    if ctk is None:
+        return False
+    if sys.platform.startswith("win"):
+        return True
+    if sys.platform == "darwin":
+        return True
+    display = os.environ.get("DISPLAY")
+    wayland = os.environ.get("WAYLAND_DISPLAY")
+    session = os.environ.get("XDG_SESSION_TYPE")
+    return bool(display or wayland or session == "wayland")
+
+
+def run_headless_query(message: str, *, show_debug: bool = False) -> str:
+    """Procesa un mensaje reutilizando la lógica de la ventana sin abrirla."""
+
+    agent = DungeonLifeAgent()
+    _, response = process_interactive_message(agent, message, show_debug=show_debug)
+    return response
+
+
+__all__ = ["AgentChatApp", "launch_app", "run_headless_query", "supports_windowing"]
+

--- a/dungeon_life_agent/interactive.py
+++ b/dungeon_life_agent/interactive.py
@@ -26,6 +26,180 @@ HELP_TEXT = """Comandos disponibles:\n" \
     "Cualquier otro texto se interpreta como consulta en modo consultor."""
 
 
+def process_interactive_message(
+    agent: DungeonLifeAgent, message: str, *, show_debug: bool = False
+) -> tuple[bool, str]:
+    """Procesa un mensaje y devuelve si continuar y la respuesta generada."""
+
+    stripped = message.strip()
+    if not stripped:
+        return True, ""
+
+    lowered = stripped.lower()
+
+    if lowered in {"salir", "exit", "quit"}:
+        return False, ""
+
+    if lowered in {"ayuda", "help"}:
+        return True, HELP_TEXT
+
+    if lowered.startswith("sugerencias"):
+        parts = stripped.split()
+        if len(parts) < 2:
+            return True, "Debes indicar al menos un prefijo para obtener sugerencias."
+        limit = 5
+        if parts[-1].isdigit():
+            limit = int(parts[-1])
+            parts = parts[:-1]
+        prefix = " ".join(parts[1:])
+        suggestions = agent.suggest_queries(prefix, limit=limit)
+        if suggestions:
+            return True, "\n".join(f"• {suggestion}" for suggestion in suggestions)
+        return True, "Sin sugerencias para ese prefijo."
+
+    if lowered.startswith("refrescar"):
+        _, *rest = stripped.split(maxsplit=1)
+        paths = [rest[0]] if rest else None
+        agent.refresh_knowledge(paths=paths)
+        return True, "Índice actualizado."
+
+    if lowered in {"metricas", "metrics"}:
+        return True, agent.get_metrics_report()
+
+    if lowered.startswith("metricas export"):
+        parts = stripped.split(maxsplit=2)
+        if len(parts) < 3:
+            return True, "Debes indicar la ruta destino: metricas export <ruta.csv>"
+        path = agent.metrics.export_csv(parts[2])
+        return True, f"Métricas exportadas a {path}"
+
+    if lowered.startswith("memoria registrar"):
+        payload = stripped[len("memoria registrar") :].strip()
+        fields = [field.strip() for field in payload.split(";") if field.strip()]
+        if len(fields) < 4:
+            return (
+                True,
+                "Formato esperado: memoria registrar "
+                "canal;autor;resumen;contenido[;tags][;decisiones]",
+            )
+        channel, author, summary, content, *extra = fields
+        tags = extra[0].split(",") if extra else []
+        decisions = extra[1].split("|") if len(extra) > 1 else []
+        record = agent.capture_memory_event(
+            channel=channel,
+            author=author,
+            summary=summary,
+            content=content,
+            tags=[tag.strip() for tag in tags if tag.strip()],
+            decisions=[decision.strip() for decision in decisions if decision.strip()],
+        )
+        return True, f"Memoria registrada ({record.identifier[:8]}…) en canal {record.channel}."
+
+    if lowered.startswith("memoria buscar"):
+        parts = stripped.split()
+        if len(parts) < 3:
+            return True, "Uso: memoria buscar <consulta> [limite]"
+        limit = 5
+        if parts[-1].isdigit():
+            limit = int(parts[-1])
+            parts = parts[:-1]
+        query = " ".join(parts[2:])
+        results = agent.search_memory(query, limit=limit)
+        if not results:
+            return True, "Sin coincidencias en memoria colectiva."
+        lines = []
+        for record in results:
+            tags = ", ".join(record.tags) if record.tags else "sin tags"
+            lines.append(
+                f"[{record.timestamp}] {record.channel} · {record.author} → "
+                f"{record.summary} ({tags})"
+            )
+        return True, "\n".join(lines)
+
+    if lowered == "memoria canales":
+        channels = agent.list_memory_channels()
+        if channels:
+            return True, "\n".join(f"• {channel}" for channel in channels)
+        return True, "Sin canales registrados aún."
+
+    if lowered == "pipeline listar":
+        pipelines = agent.list_asset_pipelines()
+        if pipelines:
+            return True, "\n".join(f"• {name}" for name in pipelines)
+        return True, "Sin pipelines registrados."
+
+    if lowered.startswith("pipeline ver"):
+        parts = stripped.split(maxsplit=2)
+        if len(parts) < 3:
+            return True, "Uso: pipeline ver <nombre>"
+        try:
+            return True, agent.describe_asset_pipeline(parts[2])
+        except ValueError as error:
+            return True, str(error)
+
+    if lowered.startswith("dataset analizar"):
+        raw_args = stripped[len("dataset analizar") :].strip().split()
+        metadata: dict[str, str] = {}
+        for item in raw_args:
+            if "=" not in item:
+                continue
+            key, value = item.split("=", 1)
+            metadata[key.strip()] = value.strip().strip('"')
+        plan = agent.plan_dataset_analysis(metadata)
+        return True, plan.render()
+
+    if lowered == "plantilla listar":
+        templates = agent.list_templates()
+        if templates:
+            return True, "\n".join(f"• {name}" for name in templates)
+        return True, "Sin plantillas registradas."
+
+    if lowered.startswith("plantilla aplicar"):
+        parts = stripped.split()
+        if len(parts) < 3:
+            return True, "Uso: plantilla aplicar <nombre> campo=valor ..."
+        name = parts[2]
+        context: dict[str, str] = {}
+        for item in parts[3:]:
+            if "=" not in item:
+                continue
+            key, value = item.split("=", 1)
+            context[key.strip()] = value.strip().strip('"')
+        try:
+            rendered = agent.apply_template(name, context)
+        except ValueError as error:
+            return True, f"Error al aplicar plantilla: {error}"
+        return True, rendered
+
+    if lowered.startswith("productividad"):
+        parts = stripped.split()
+        if len(parts) != 4:
+            return True, "Uso: productividad <rol> <tareas_completadas> <minutos>"
+        role = parts[1]
+        try:
+            tasks = int(parts[2])
+            minutes = float(parts[3])
+        except ValueError:
+            return True, "Tareas debe ser entero y minutos un número."
+        agent.register_productivity(
+            role=role, tasks_completed=tasks, session_minutes=minutes
+        )
+        return True, "Registro de productividad agregado."
+
+    if lowered.startswith("lm generar"):
+        prompt = stripped[len("lm generar") :].strip()
+        if not prompt:
+            return True, "Debes proporcionar un prompt para el modelo de lenguaje."
+        try:
+            output = agent.generate_with_model(prompt)
+        except RuntimeError as error:
+            return True, str(error)
+        return True, output
+
+    response = agent.query(stripped)
+    return True, response.format_text(show_debug=show_debug)
+
+
 def run_interactive(
     agent: DungeonLifeAgent, *, greeting: Optional[str] = None
 ) -> None:
@@ -34,224 +208,23 @@ def run_interactive(
     if greeting:
         print(greeting)
 
+    show_debug = bool(os.environ.get("WILLOW_DEBUG_TRACE"))
+
     while True:
         try:
-            message = input("consulta> ").strip()
+            message = input("consulta> ")
         except (EOFError, KeyboardInterrupt):
             print()  # nueva línea
             break
 
-        lowered = message.lower()
+        should_continue, output = process_interactive_message(
+            agent, message, show_debug=show_debug
+        )
 
-        if lowered in {"salir", "exit", "quit"}:
+        if output:
+            print(output)
+            print()
+
+        if not should_continue:
             break
-
-        if lowered in {"ayuda", "help"}:
-            print(HELP_TEXT)
-            print()
-            continue
-
-        if lowered.startswith("sugerencias"):
-            parts = message.split()
-            if len(parts) < 2:
-                print("Debes indicar al menos un prefijo para obtener sugerencias.")
-                print()
-                continue
-            limit = 5
-            if parts[-1].isdigit():
-                limit = int(parts[-1])
-                parts = parts[:-1]
-            prefix = " ".join(parts[1:])
-            suggestions = agent.suggest_queries(prefix, limit=limit)
-            if suggestions:
-                for suggestion in suggestions:
-                    print(f"• {suggestion}")
-            else:
-                print("Sin sugerencias para ese prefijo.")
-            print()
-            continue
-
-        if lowered.startswith("refrescar"):
-            _, *rest = message.split(maxsplit=1)
-            paths = [rest[0]] if rest else None
-            agent.refresh_knowledge(paths=paths)
-            print("Índice actualizado.")
-            print()
-            continue
-
-        if lowered in {"metricas", "metrics"}:
-            print(agent.get_metrics_report())
-            print()
-            continue
-
-        if lowered.startswith("metricas export"):
-            parts = message.split(maxsplit=2)
-            if len(parts) < 3:
-                print("Debes indicar la ruta destino: metricas export <ruta.csv>")
-            else:
-                path = agent.metrics.export_csv(parts[2])
-                print(f"Métricas exportadas a {path}")
-            print()
-            continue
-
-        if lowered.startswith("memoria registrar"):
-            payload = message[len("memoria registrar") :].strip()
-            fields = [field.strip() for field in payload.split(";") if field.strip()]
-            if len(fields) < 4:
-                print(
-                    "Formato esperado: memoria registrar "
-                    "canal;autor;resumen;contenido[;tags][;decisiones]"
-                )
-                print()
-                continue
-            channel, author, summary, content, *extra = fields
-            tags = extra[0].split(",") if extra else []
-            decisions = extra[1].split("|") if len(extra) > 1 else []
-            record = agent.capture_memory_event(
-                channel=channel,
-                author=author,
-                summary=summary,
-                content=content,
-                tags=[tag.strip() for tag in tags if tag.strip()],
-                decisions=[decision.strip() for decision in decisions if decision.strip()],
-            )
-            print(f"Memoria registrada ({record.identifier[:8]}…) en canal {record.channel}.")
-            print()
-            continue
-
-        if lowered.startswith("memoria buscar"):
-            parts = message.split()
-            if len(parts) < 3:
-                print("Uso: memoria buscar <consulta> [limite]")
-                print()
-                continue
-            limit = 5
-            if parts[-1].isdigit():
-                limit = int(parts[-1])
-                parts = parts[:-1]
-            query = " ".join(parts[2:])
-            results = agent.search_memory(query, limit=limit)
-            if not results:
-                print("Sin coincidencias en memoria colectiva.")
-            else:
-                for record in results:
-                    tags = ", ".join(record.tags) if record.tags else "sin tags"
-                    print(
-                        f"[{record.timestamp}] {record.channel} · {record.author} → "
-                        f"{record.summary} ({tags})"
-                    )
-            print()
-            continue
-
-        if lowered == "memoria canales":
-            channels = agent.list_memory_channels()
-            if channels:
-                for channel in channels:
-                    print(f"• {channel}")
-            else:
-                print("Sin canales registrados aún.")
-            print()
-            continue
-
-        if lowered == "pipeline listar":
-            for name in agent.list_asset_pipelines():
-                print(f"• {name}")
-            print()
-            continue
-
-        if lowered.startswith("pipeline ver"):
-            parts = message.split(maxsplit=2)
-            if len(parts) < 3:
-                print("Uso: pipeline ver <nombre>")
-            else:
-                try:
-                    print(agent.describe_asset_pipeline(parts[2]))
-                except ValueError as error:
-                    print(error)
-            print()
-            continue
-
-        if lowered.startswith("dataset analizar"):
-            raw_args = message[len("dataset analizar") :].strip().split()
-            metadata: dict[str, str] = {}
-            for item in raw_args:
-                if "=" not in item:
-                    continue
-                key, value = item.split("=", 1)
-                metadata[key.strip()] = value.strip().strip('"')
-            plan = agent.plan_dataset_analysis(metadata)
-            print(plan.render())
-            print()
-            continue
-
-        if lowered == "plantilla listar":
-            for name in agent.list_templates():
-                print(f"• {name}")
-            print()
-            continue
-
-        if lowered.startswith("plantilla aplicar"):
-            parts = message.split()
-            if len(parts) < 3:
-                print("Uso: plantilla aplicar <nombre> campo=valor ...")
-                print()
-                continue
-            name = parts[2]
-            context: dict[str, str] = {}
-            for item in parts[3:]:
-                if "=" not in item:
-                    continue
-                key, value = item.split("=", 1)
-                context[key.strip()] = value.strip().strip('"')
-            try:
-                rendered = agent.apply_template(name, context)
-            except ValueError as error:
-                print(f"Error al aplicar plantilla: {error}")
-            else:
-                print(rendered)
-            print()
-            continue
-
-        if lowered.startswith("productividad"):
-            parts = message.split()
-            if len(parts) != 4:
-                print("Uso: productividad <rol> <tareas_completadas> <minutos>")
-                print()
-                continue
-            role = parts[1]
-            try:
-                tasks = int(parts[2])
-                minutes = float(parts[3])
-            except ValueError:
-                print("Tareas debe ser entero y minutos un número.")
-            else:
-                agent.register_productivity(
-                    role=role, tasks_completed=tasks, session_minutes=minutes
-                )
-                print("Registro de productividad agregado.")
-            print()
-            continue
-
-        if lowered.startswith("lm generar"):
-            prompt = message[len("lm generar") :].strip()
-            if not prompt:
-                print("Debes proporcionar un prompt para el modelo de lenguaje.")
-                print()
-                continue
-            try:
-                output = agent.generate_with_model(prompt)
-            except RuntimeError as error:
-                print(error)
-            else:
-                print(output)
-            print()
-            continue
-
-        if not message:
-            continue
-
-        response = agent.query(message)
-        show_debug = bool(os.environ.get("WILLOW_DEBUG_TRACE"))
-        print(response.format_text(show_debug=show_debug))
-        print()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
     "requests>=2.31.0",
+    "customtkinter>=5.2.0",
 ]
 
 [project.scripts]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 requests>=2.31.0
+customtkinter>=5.2.0

--- a/run_gui.py
+++ b/run_gui.py
@@ -1,0 +1,55 @@
+"""Lanza la interfaz gráfica de Willow o ejecuta consultas en modo headless."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+from dungeon_life_agent.gui import launch_app, run_headless_query, supports_windowing
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Interfaz gráfica y pruebas rápidas de Willow")
+    parser.add_argument("--ask", metavar="PREGUNTA", help="Realiza una consulta rápida sin abrir la ventana")
+    parser.add_argument(
+        "--debug",
+        action="store_true",
+        help="Incluye trazas del pipeline de búsqueda en la respuesta headless",
+    )
+    parser.add_argument(
+        "--no-gui",
+        action="store_true",
+        help="Evita lanzar la ventana incluso si hay entorno gráfico disponible",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    if args.ask:
+        output = run_headless_query(args.ask, show_debug=args.debug)
+        if output:
+            print(output)
+        else:
+            print("No se generó respuesta para la consulta proporcionada.", file=sys.stderr)
+        if args.no_gui or not supports_windowing():
+            return 0
+
+    if args.no_gui:
+        return 0
+
+    if not supports_windowing():
+        print(
+            "Entorno gráfico no disponible. Exporta DISPLAY/WAYLAND_DISPLAY o usa --no-gui.",
+            file=sys.stderr,
+        )
+        return 2
+
+    launch_app()
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - punto de entrada manual
+    sys.exit(main())

--- a/tests/test_gui_headless.py
+++ b/tests/test_gui_headless.py
@@ -1,0 +1,24 @@
+"""Pruebas del modo headless de la interfaz gráfica."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+from dungeon_life_agent.gui import run_headless_query
+
+
+def test_headless_query_returns_craft_definition():
+    output = run_headless_query("sabes que es CRAFT?")
+    assert "Creative Framework for Augmented Fantasy Teams" in output
+
+
+def test_cli_allows_headless_query(tmp_path):
+    result = subprocess.run(
+        [sys.executable, "run_gui.py", "--ask", "sabes que es CRAFT?", "--no-gui"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert "Creative Framework for Augmented Fantasy Teams" in result.stdout
+    assert result.stderr == ""


### PR DESCRIPTION
## Summary
- add a dedicated manual describing the CRAFT methodology to the project documentation
- make the CustomTkinter chat app degrade gracefully in headless environments and expose a helper for scripted queries
- extend `run_gui.py` with a `--ask` headless option and cover the flow with automated tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e81b80280083238e553d768bb35c5e